### PR TITLE
Fix Nesting Problems

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -29,11 +29,11 @@ return [
             // https://s9etextformatter.readthedocs.io/Plugins/BBCodes/Add_custom_BBCodes/
             $config->BBCodes->addCustom(
                 '[REPLY]{TEXT}[/REPLY]',
-                '<div><reply2see />{TEXT}<reply2see /></div>'
+                '<div><reply2see></reply2see>{TEXT}<reply2see></reply2see></div>'
             );
             $config->BBCodes->addCustom(
                 '[LOGIN]{TEXT}[/LOGIN]',
-                '<div><login2see />{TEXT}<login2see /></div>'
+                '<div><login2see></login2see>{TEXT}<login2see></login2see></div>'
             );
             $config->BBCodes->addCustom(
                 '[cloud type={TEXT1} title={TEXT2} url={URL}]{TEXT3}[/cloud]',

--- a/extend.php
+++ b/extend.php
@@ -29,11 +29,11 @@ return [
             // https://s9etextformatter.readthedocs.io/Plugins/BBCodes/Add_custom_BBCodes/
             $config->BBCodes->addCustom(
                 '[REPLY]{TEXT}[/REPLY]',
-                '<reply2see>{TEXT}</reply2see>'
+                '<div><reply2see />{TEXT}<reply2see /></div>'
             );
             $config->BBCodes->addCustom(
                 '[LOGIN]{TEXT}[/LOGIN]',
-                '<login2see>{TEXT}</login2see>'
+                '<div><login2see />{TEXT}<login2see /></div>'
             );
             $config->BBCodes->addCustom(
                 '[cloud type={TEXT1} title={TEXT2} url={URL}]{TEXT3}[/cloud]',

--- a/src/ReplaceCode.php
+++ b/src/ReplaceCode.php
@@ -21,12 +21,12 @@ class ReplaceCode extends FormatContent
             }
 
             // 登录可见
-            if (str_contains($attributes["contentHtml"], '<login2see>')) {
+            if (str_contains($attributes["contentHtml"], '<login2see />')) {
                 $attributes = $this->login($serializer, $post, $attributes);
             }
 
             // 回复可见
-            if (str_contains($attributes["contentHtml"], '<reply2see>')) {
+            if (str_contains($attributes["contentHtml"], '<reply2see />')) {
                 $attributes = $this->reply($serializer, $post, $attributes);
             }
         }
@@ -58,7 +58,7 @@ class ReplaceCode extends FormatContent
         }
 
         if ($replied) {
-            $newHTML = preg_replace('/<reply2see>(.*?)<\/reply2see>/is',
+            $newHTML = preg_replace('/<div><reply2see \/>(.*?)<reply2see \/><\/div>/is',
                 '<div class="reply2see"><div class="reply2see_title">' .
                 $this->translator->trans('imeepo-more-bbcode.forum.hidden_content_reply')
                 . '</div>$1</div>',
@@ -66,7 +66,7 @@ class ReplaceCode extends FormatContent
             );
         } else {
             $newHTML = preg_replace(
-                '/<reply2see>(.*?)<\/reply2see>/is',
+                '/<div><reply2see \/>(.*?)<reply2see \/><\/div>/is',
                 '<div class="reply2see"><div class="reply2see_alert">' .
                 $this->translator->trans('imeepo-more-bbcode.forum.reply_to_see',
                     array(
@@ -106,7 +106,7 @@ class ReplaceCode extends FormatContent
         }
 
         if ($logined) {
-            $newHTML = preg_replace('/<login2see>(.*?)<\/login2see>/is',
+            $newHTML = preg_replace('/<div><login2see \/>(.*?)<login2see \/><\/div>/is',
                 '<div class="login2see"><div class="login2see_title">' .
                 $this->translator->trans('imeepo-more-bbcode.forum.hidden_content_login')
                 . '</div>$1</div>',
@@ -114,7 +114,7 @@ class ReplaceCode extends FormatContent
             );
         } else {
             $newHTML = preg_replace(
-                '/<login2see>(.*?)<\/login2see>/is',
+                '/<div><login2see \/>(.*?)<login2see \/><\/div>/is',
                 '<div class="login2see"><div class="login2see_alert">' .
                 $this->translator->trans('imeepo-more-bbcode.forum.login_to_see',
                     array(

--- a/src/ReplaceCode.php
+++ b/src/ReplaceCode.php
@@ -21,12 +21,12 @@ class ReplaceCode extends FormatContent
             }
 
             // 登录可见
-            if (str_contains($attributes["contentHtml"], '<login2see />')) {
+            if (str_contains($attributes["contentHtml"], '<login2see><login2see/>')) {
                 $attributes = $this->login($serializer, $post, $attributes);
             }
 
             // 回复可见
-            if (str_contains($attributes["contentHtml"], '<reply2see />')) {
+            if (str_contains($attributes["contentHtml"], '<reply2see><reply2see/>')) {
                 $attributes = $this->reply($serializer, $post, $attributes);
             }
         }
@@ -58,7 +58,7 @@ class ReplaceCode extends FormatContent
         }
 
         if ($replied) {
-            $newHTML = preg_replace('/<div><reply2see \/>(.*?)<reply2see \/><\/div>/is',
+            $newHTML = preg_replace('/<div><reply2see><\/reply2see>(.*?)<reply2see><\/reply2see><\/div>/is',
                 '<div class="reply2see"><div class="reply2see_title">' .
                 $this->translator->trans('imeepo-more-bbcode.forum.hidden_content_reply')
                 . '</div>$1</div>',
@@ -66,7 +66,7 @@ class ReplaceCode extends FormatContent
             );
         } else {
             $newHTML = preg_replace(
-                '/<div><reply2see \/>(.*?)<reply2see \/><\/div>/is',
+                '/<div><reply2see><\/reply2see>(.*?)<reply2see><\/reply2see><\/div>/is',
                 '<div class="reply2see"><div class="reply2see_alert">' .
                 $this->translator->trans('imeepo-more-bbcode.forum.reply_to_see',
                     array(
@@ -106,7 +106,7 @@ class ReplaceCode extends FormatContent
         }
 
         if ($logined) {
-            $newHTML = preg_replace('/<div><login2see \/>(.*?)<login2see \/><\/div>/is',
+            $newHTML = preg_replace('/<div><login2see><\/login2see>(.*?)<login2see><\/login2see><\/div>/is',
                 '<div class="login2see"><div class="login2see_title">' .
                 $this->translator->trans('imeepo-more-bbcode.forum.hidden_content_login')
                 . '</div>$1</div>',
@@ -114,7 +114,7 @@ class ReplaceCode extends FormatContent
             );
         } else {
             $newHTML = preg_replace(
-                '/<div><login2see \/>(.*?)<login2see \/><\/div>/is',
+                '/<div><login2see><\/login2see>(.*?)<login2see><\/login2see><\/div>/is',
                 '<div class="login2see"><div class="login2see_alert">' .
                 $this->translator->trans('imeepo-more-bbcode.forum.login_to_see',
                     array(

--- a/src/ReplaceCode.php
+++ b/src/ReplaceCode.php
@@ -21,12 +21,12 @@ class ReplaceCode extends FormatContent
             }
 
             // 登录可见
-            if (str_contains($attributes["contentHtml"], '<login2see><login2see/>')) {
+            if (str_contains($attributes["contentHtml"], '<login2see></login2see>')) {
                 $attributes = $this->login($serializer, $post, $attributes);
             }
 
             // 回复可见
-            if (str_contains($attributes["contentHtml"], '<reply2see><reply2see/>')) {
+            if (str_contains($attributes["contentHtml"], '<reply2see></reply2see>')) {
                 $attributes = $this->reply($serializer, $post, $attributes);
             }
         }


### PR DESCRIPTION
s9e/text-formatter的特性导致了当解析后的模板中出现非标准HTML标签时其内部嵌套的标签将不会被解析。
The feature of s9e/text-formatter leads to the fact that when non-standard HTML tags appeared in the template after parsing, the tags nested inside it will not be parsed.

该提交将代码中用到的非标准HTML替换成了标准HTML和两对自闭合标签。
The commit replaces the non-standard HTML used in the code with standard HTML and two pairs of self-closing tags.